### PR TITLE
Updating for 2021

### DIFF
--- a/bash/add.php
+++ b/bash/add.php
@@ -51,7 +51,7 @@ server {
 	location ~ \.php$ {
 		try_files \\\$uri =404;
 		include global/fastcgi-params.conf;
-		fastcgi_pass unix:/var/run/php/php7.4-fpm.sock;
+		fastcgi_pass unix:/var/run/php/php8.0-fpm.sock;
 	}
 }
 

--- a/install.sh
+++ b/install.sh
@@ -44,12 +44,11 @@ runcmd:
   - mv wp-cli.phar /usr/local/bin/wp
   - apt-get install -y mysql-server
   - service mysql stop
-  - echo "" >> /etc/mysql/conf.d/mysql.cnf
-  - echo "[mysqld]" >> /etc/mysql/conf.d/mysql.cnf
-  - echo "default_authentication_plugin=mysql_native_password" >> /etc/mysql/conf.d/mysql.cnf
+  - echo "" >> /etc/mysql/mysql.conf.d/mysqld.cnf
+  - echo "default_authentication_plugin=mysql_native_password" >> /etc/mysql/mysql.conf.d/mysqld.cnf
   - service mysql start
   - mysql -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';"
-  - mysql -e "FLUSH PRIVILEGES;"
+  - mysql -uroot -proot -e "FLUSH PRIVILEGES;"
 EOT
 
 mkdir -p ~/wp-cli-up

--- a/install.sh
+++ b/install.sh
@@ -12,16 +12,6 @@ runcmd:
   - add-apt-repository --no-update universe
   - add-apt-repository --no-update -y ppa:ondrej/php
   - add-apt-repository --no-update -y ppa:ondrej/nginx
-  - apt-key adv --fetch-keys 'https://mariadb.org/mariadb_release_signing_key.asc'
-  - add-apt-repository --no-update -y 'deb [arch=amd64,arm64,ppc64el] http://mirrors.up.pt/pub/mariadb/repo/10.4/ubuntu focal main'
-  - mkdir -p /home/ubuntu/.composer
-  - echo "COMPOSER_HOME=/home/ubuntu/.composer" >> /etc/environment
-  - curl -sS https://getcomposer.org/installer -o composer-setup.php
-  - php composer-setup.php --install-dir=/usr/local/bin --filename=composer
-  - rm composer-setup.php
-  - curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
-  - chmod +x wp-cli.phar
-  - mv wp-cli.phar /usr/local/bin/wp
   - apt-get update -y
   - apt-get install -y nginx
   - mkdir -p /etc/nginx/ssl
@@ -31,26 +21,34 @@ runcmd:
   - rm -Rf nginx-config-kit-for-wordpress-1.3*
   - perl -p -i -e 's/^user .*/user ubuntu;/g' /etc/nginx/nginx.conf
   - service nginx reload
-  - apt-get install -y php7.4-fpm php7.4-common php7.4-mysql php7.4-xml php7.4-xmlrpc php7.4-curl php7.4-gd php7.4-imagick php7.4-cli php7.4-dev php7.4-imap php7.4-mbstring php7.4-opcache php7.4-redis php7.4-soap php7.4-zip
-  - perl -p -i -e 's/upload_max_filesize = .*/upload_max_filesize = 64M/g' /etc/php/7.4/fpm/php.ini
-  - perl -p -i -e 's/post_max_size = .*/post_max_size = 64M/g' /etc/php/7.4/fpm/php.ini
-  - perl -p -i -e 's/pm.max_children = .*/pm.max_children = 10/g' /etc/php/7.4/fpm/pool.d/www.conf
-  - perl -p -i -e 's/pm.start_servers = .*/pm.start_servers = 4/g' /etc/php/7.4/fpm/pool.d/www.conf
-  - perl -p -i -e 's/pm.min_spare_servers = .*/pm.min_spare_servers = 2/g' /etc/php/7.4/fpm/pool.d/www.conf
-  - perl -p -i -e 's/pm.max_spare_servers = .*/pm.max_spare_servers = 6/g' /etc/php/7.4/fpm/pool.d/www.conf
-  - perl -p -i -e 's/pm.max_spare_servers = .*/pm.max_spare_servers = 6/g' /etc/php/7.4/fpm/pool.d/www.conf
-  - perl -p -i -e 's/user = .*/user = ubuntu/g' /etc/php/7.4/fpm/pool.d/www.conf
-  - perl -p -i -e 's/group = .*/group = ubuntu/g' /etc/php/7.4/fpm/pool.d/www.conf
-  - perl -p -i -e 's/listen.owner = .*/listen.owner = ubuntu/g' /etc/php/7.4/fpm/pool.d/www.conf
-  - perl -p -i -e 's/listen.group = .*/listen.group = ubuntu/g' /etc/php/7.4/fpm/pool.d/www.conf
-  - service php7.4-fpm restart
-  - apt-get install -y mariadb-server
-  - mysql -e "UPDATE mysql.global_priv SET priv=json_set(priv, '$.password_last_changed', UNIX_TIMESTAMP(), '$.plugin', 'mysql_native_password', '$.authentication_string', 'invalid', '$.auth_or', json_array(json_object(), json_object('plugin', 'unix_socket'))) WHERE User='root';"
-  - mysql -e "UPDATE mysql.global_priv SET priv=json_set(priv, '$.plugin', 'mysql_native_password', '$.authentication_string', PASSWORD('root')) WHERE User='root';"
-  - mysql -e "DELETE FROM mysql.global_priv WHERE User='';"
-  - mysql -e "DELETE FROM mysql.global_priv WHERE User='root' AND Host NOT IN ('localhost', '127.0.0.1', '::1');"
-  - mysql -e "DROP DATABASE IF EXISTS test;"
-  - mysql -e "DELETE FROM mysql.db WHERE Db='test' OR Db='test\\_%'"
+  - apt-get install -y php8.0-fpm php8.0-common php8.0-mysql php8.0-xml php8.0-xmlrpc php8.0-curl php8.0-gd php8.0-imagick php8.0-cli php8.0-dev php8.0-imap php8.0-mbstring php8.0-opcache php8.0-redis php8.0-soap php8.0-zip
+  - perl -p -i -e 's/upload_max_filesize = .*/upload_max_filesize = 64M/g' /etc/php/8.0/fpm/php.ini
+  - perl -p -i -e 's/post_max_size = .*/post_max_size = 64M/g' /etc/php/8.0/fpm/php.ini
+  - perl -p -i -e 's/pm.max_children = .*/pm.max_children = 10/g' /etc/php/8.0/fpm/pool.d/www.conf
+  - perl -p -i -e 's/pm.start_servers = .*/pm.start_servers = 4/g' /etc/php/8.0/fpm/pool.d/www.conf
+  - perl -p -i -e 's/pm.min_spare_servers = .*/pm.min_spare_servers = 2/g' /etc/php/8.0/fpm/pool.d/www.conf
+  - perl -p -i -e 's/pm.max_spare_servers = .*/pm.max_spare_servers = 6/g' /etc/php/8.0/fpm/pool.d/www.conf
+  - perl -p -i -e 's/pm.max_spare_servers = .*/pm.max_spare_servers = 6/g' /etc/php/8.0/fpm/pool.d/www.conf
+  - perl -p -i -e 's/user = .*/user = ubuntu/g' /etc/php/8.0/fpm/pool.d/www.conf
+  - perl -p -i -e 's/group = .*/group = ubuntu/g' /etc/php/8.0/fpm/pool.d/www.conf
+  - perl -p -i -e 's/listen.owner = .*/listen.owner = ubuntu/g' /etc/php/8.0/fpm/pool.d/www.conf
+  - perl -p -i -e 's/listen.group = .*/listen.group = ubuntu/g' /etc/php/8.0/fpm/pool.d/www.conf
+  - service php8.0-fpm restart
+  - mkdir -p /home/ubuntu/.composer
+  - echo "COMPOSER_HOME=/home/ubuntu/.composer" >> /etc/environment
+  - curl -sS https://getcomposer.org/installer -o composer-setup.php
+  - php composer-setup.php --install-dir=/usr/local/bin --filename=composer
+  - rm composer-setup.php
+  - curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
+  - chmod +x wp-cli.phar
+  - mv wp-cli.phar /usr/local/bin/wp
+  - apt-get install -y mysql-server
+  - service mysql stop
+  - echo "" >> /etc/mysql/conf.d/mysql.cnf
+  - echo "[mysqld]" >> /etc/mysql/conf.d/mysql.cnf
+  - echo "default_authentication_plugin=mysql_native_password" >> /etc/mysql/conf.d/mysql.cnf
+  - service mysql start
+  - mysql -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';"
   - mysql -e "FLUSH PRIVILEGES;"
 EOT
 


### PR DESCRIPTION
- Updates PHP to 8.0
- Switches from MariaDB to MySQL 8.0
- Updates MySQL 8.0 password authentication method to native_password
- Moves composer and wp-cli install to after server software is installed, otherwise `php composer-setup.php` throws an error.

Fixes #2 